### PR TITLE
get all product types-added headers to gets

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -1,6 +1,6 @@
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from views import get_all_products, get_single_product
+from views import get_all_products, get_single_product, get_all_product_types
 
 
 class HandleRequests(BaseHTTPRequestHandler):
@@ -25,15 +25,23 @@ class HandleRequests(BaseHTTPRequestHandler):
     def do_GET(self):
         """Handles GET requests to the server
         """
-        self._set_headers(200)
+        
         (resource, id) = self.parse_url(self.path)
 
         if resource == "products":
             if id is not None:
+                self._set_headers(200)
                 response = get_single_product(id)
             else:
+                self._set_headers(200)
                 response = get_all_products()
-
+        elif resource == "product_types":
+            if id is not None:
+                self._set_headers(405)
+                response = ""
+            else:
+                self._set_headers(200)
+                response = get_all_product_types()
         else:
             response = []
 

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,2 +1,3 @@
 from .product_view import get_all_products
 from .product_view import get_single_product
+from .product_type_view import get_all_product_types

--- a/views/product_type_view.py
+++ b/views/product_type_view.py
@@ -1,7 +1,7 @@
 PRODUCT_TYPES = [
-    {"id": 1,
-    "description": "burrito"
-
+    {
+        "id": 1,
+        "description": "burrito"
     },
     {
         "id": 2,
@@ -17,10 +17,11 @@ PRODUCT_TYPES = [
     }
 ]
 
+
 def get_all_product_types():
-    """Get entire list of products
+    """Get entire list of product types
 
     Returns:
-        list: The list of product dictionaries
+        list: The list of product type dictionaries
     """
     return PRODUCT_TYPES

--- a/views/product_type_view.py
+++ b/views/product_type_view.py
@@ -1,0 +1,26 @@
+PRODUCT_TYPES = [
+    {"id": 1,
+    "description": "burrito"
+
+    },
+    {
+        "id": 2,
+        "description": "bowl"
+    },
+    {
+        "id": 3,
+        "description": "taco"
+    },
+    {
+        "id": 4,
+        "description": "chalupa"
+    }
+]
+
+def get_all_product_types():
+    """Get entire list of products
+
+    Returns:
+        list: The list of product dictionaries
+    """
+    return PRODUCT_TYPES


### PR DESCRIPTION
Closes #1

# Description
Added get all product types.  Added headers to each get.

# Steps to test

1. Pull the `sydney-get-product-types` branch and switch to it
2. Start the API in debug mode
3. Open Postman and request all product types, verify that you get a list.
4. Verify correct headers on get, and 405 on get single product type
