### PR TITLE
can add product types

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -2,7 +2,7 @@ import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from views import (
     get_all_products, get_single_product,
-    get_all_product_types, get_product_id
+    get_all_product_types, get_product_id, create_product_type
 )
 
 
@@ -52,14 +52,16 @@ class HandleRequests(BaseHTTPRequestHandler):
         self.wfile.write(json.dumps(response).encode())
 
     def do_POST(self):
-        """Handles POST requests to the server"""
-
         self._set_headers(201)
-
         content_len = int(self.headers.get('content-length', 0))
         post_body = self.rfile.read(content_len)
-        response = { "payload": post_body }
-        self.wfile.write(json.dumps(response).encode())
+
+        post_body = json.loads(post_body)
+        (resource, id) = self.parse_url(self.path)
+        new_post = None
+        if resource == "product_types":
+            new_post = create_product_type(post_body)
+        self.wfile.write(json.dumps(new_post).encode())
 
     def do_PUT(self):
         """Handles PUT requests to the server"""

--- a/request_handler.py
+++ b/request_handler.py
@@ -39,7 +39,7 @@ class HandleRequests(BaseHTTPRequestHandler):
             else:
                 self._set_headers(200)
                 response = get_all_products()
-        elif resource == "product_types":
+        elif resource == "types":
             if id is not None:
                 self._set_headers(405)
                 response = ""
@@ -52,15 +52,20 @@ class HandleRequests(BaseHTTPRequestHandler):
         self.wfile.write(json.dumps(response).encode())
 
     def do_POST(self):
-        self._set_headers(201)
         content_len = int(self.headers.get('content-length', 0))
         post_body = self.rfile.read(content_len)
 
         post_body = json.loads(post_body)
         (resource, id) = self.parse_url(self.path)
         new_post = None
-        if resource == "product_types":
+        if resource == "types":
             new_post = create_product_type(post_body)
+            if 'id' in new_post:
+                self._set_headers(201)
+            else:
+                self._set_headers(400)
+
+
         self.wfile.write(json.dumps(new_post).encode())
 
     def do_PUT(self):

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
 from .product_view import get_all_products
 from .product_view import get_single_product
 from .product_view import get_product_id
-from .product_type_view import get_all_product_types
+from .product_type_view import get_all_product_types, create_product_type

--- a/views/product_type_view.py
+++ b/views/product_type_view.py
@@ -25,3 +25,15 @@ def get_all_product_types():
         list: The list of product type dictionaries
     """
     return PRODUCT_TYPES
+
+def create_product_type(product_type):
+    """Create a product type
+
+    Returns:
+        the new product type
+    """
+    max_id = PRODUCT_TYPES[-1]["id"]
+    new_id = max_id + 1
+    product_type["id"] = new_id
+    PRODUCT_TYPES.append(product_type)
+    return product_type

--- a/views/product_type_view.py
+++ b/views/product_type_view.py
@@ -32,8 +32,11 @@ def create_product_type(product_type):
     Returns:
         the new product type
     """
-    max_id = PRODUCT_TYPES[-1]["id"]
-    new_id = max_id + 1
-    product_type["id"] = new_id
-    PRODUCT_TYPES.append(product_type)
-    return product_type
+    if "description" in product_type:
+        max_id = PRODUCT_TYPES[-1]["id"]
+        product_type["id"] = max_id + 1
+        PRODUCT_TYPES.append(product_type)
+        return product_type
+    else:
+        return {}
+  


### PR DESCRIPTION
Closes #7

#Description
Added create_product_type in product type view, added create product type to do_post

#Steps to test
Pull the sydney-add-product-type and switch to it
Start the API in debug mode
Open Postman and Post a product type 
   {
        "id": 4,
        "description": "test me"
    }
http://localhost:8088/product_types
Verify that you get a single dictionary back.
GET all product types and make sure the new type has been added