### PR TITLE
Product dictionaries can now be removed from the list

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -35,8 +35,14 @@ class HandleRequests(BaseHTTPRequestHandler):
 
         if resource == "products":
             if id is not None:
-                self._set_headers(200)
                 response = get_single_product(id)
+
+                if response is not None:
+                    self._set_headers(200)
+                else:
+                    response = ""
+                    self._set_headers(404)
+
             else:
                 self._set_headers(200)
                 response = get_all_products()

--- a/request_handler.py
+++ b/request_handler.py
@@ -2,7 +2,8 @@ import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from views import (
     get_all_products, get_single_product,
-    get_all_product_types, get_product_id
+    get_all_product_types, get_product_id,
+    remove_product
 )
 
 
@@ -60,6 +61,23 @@ class HandleRequests(BaseHTTPRequestHandler):
         post_body = self.rfile.read(content_len)
         response = { "payload": post_body }
         self.wfile.write(json.dumps(response).encode())
+
+    def do_DELETE(self):
+        """Handle all DELETE requests
+        """
+        (resource, id) = self.parse_url(self.path)
+
+        success = False
+        if resource == 'products':
+            success = remove_product(id)
+
+        if success:
+            self._set_headers(204)
+        else:
+            self._set_headers(404)
+
+        self.wfile.write("".encode())
+
 
     def do_PUT(self):
         """Handles PUT requests to the server"""

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,5 @@
 from .product_view import get_all_products
 from .product_view import get_single_product
 from .product_view import get_product_id
+from .product_view import remove_product
 from .product_type_view import get_all_product_types

--- a/views/product_view.py
+++ b/views/product_view.py
@@ -38,6 +38,26 @@ PRODUCTS = [
     }
 ]
 
+def remove_product(id):
+    """Remove a dictionary from the product list
+
+    Args:
+        id (int): Primary key of item to delete
+
+    Returns:
+        bool: Whether the product was found an deleted
+    """
+    index_to_remove = -1
+
+    for index, product in enumerate(PRODUCTS):
+        if product['id'] == id:
+            index_to_remove = index
+
+    if index_to_remove > -1:
+        del PRODUCTS[index_to_remove]
+        return True
+    else:
+        return False
 
 def get_product_id():
     """Get a random primary key of a dictionary in the product list


### PR DESCRIPTION
Closes #5

# Description

A new `do_DELETE` function added to main module to handle DELETE requests. New function added to product view to find a product's index by the id and delete if it is found.

# Steps to test

1. Fetch the `steve-remove_product` branch and switch to it
2. Start/restart debugger
3. Send a DELETE request for an existing product (e.g. http://localhost:8088/products/1) 
4. Verify that 204 status code is received
5. Request all products and verify it was deleted
6. Send a DELETE request for a non-existant product (e.g. http://localhost:8088/products/1000) 
7. Verify that 404 status code is received